### PR TITLE
fixed bug in order by clause while in postgresql

### DIFF
--- a/lib/positionable.rb
+++ b/lib/positionable.rb
@@ -66,7 +66,7 @@ module Positionable
       start = options[:start] || 0
       order = options[:order] || :asc
 
-      default_scope order("`#{self.table_name}`.`position` #{order}")
+      default_scope order("\"#{self.table_name}\".\"position\" #{order}")
 
       before_create :add_to_bottom
       before_update :update_position

--- a/positionable.gemspec
+++ b/positionable.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "rspec", "~> 2.3"
-  s.add_development_dependency "sqlite3-ruby"
+  s.add_development_dependency "sqlite3"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "factory_girl"
 

--- a/spec/lib/positionable_spec.rb
+++ b/spec/lib/positionable_spec.rb
@@ -28,7 +28,7 @@ describe Positionable do
     it "prepends the table name in SQL 'order by' clause" do
       sql = DefaultItem.where("1 = 1").to_sql
       table = DefaultItem.table_name
-      sql.should include("ORDER BY `#{table}`.`position`")
+      sql.should include("ORDER BY \"#{table}\".\"position\"")
     end
 
     context "inheritance" do


### PR DESCRIPTION
You were placing default order with back ticks, that was breaking while running on postgresql.
This commit fixes it.
Additionally I renamed sqlite3-ruby gem to sqlite3 in dependencies, they renamed it
